### PR TITLE
2601 fix/misc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,11 @@ repos:
       - id: mixed-line-ending
       - id: pretty-format-json
         args: ['--autofix', '--no-sort-keys']
+  - repo: local
+    hooks:
+      - id: format-xml
+        name: Format XML
+        language: python
+        entry: python format_xml.py
+        types: [xml]
+        additional_dependencies: ['lxml==4.6.1']

--- a/SEED Benchmark/OEI/classes/SEEDPropertyToSFBenchmark.groovy
+++ b/SEED Benchmark/OEI/classes/SEEDPropertyToSFBenchmark.groovy
@@ -11,6 +11,7 @@ Benchmark = [
 
 	// Custom fields per Org
 	oei__Contact_Name__c: flowVars["ContactResults"],
+	oei_Property_Data_Administrator__c: flowVars["AdminContactResults"],
 	oei__Diff_from_National_Median_Site_EUI__c: propData["% Difference from National Median Site EUI"],
 	oei__Diff_than_National_Median_Source_EUI__c: propData["% Difference from National Median Source EUI"],
 	oei__ENERGY_STAR_Score__c: propData["ENERGY STAR Score"],

--- a/SEED Benchmark/OEI/classes/pollseedforproperties.xml
+++ b/SEED Benchmark/OEI/classes/pollseedforproperties.xml
@@ -1,13 +1,9 @@
 <mule xmlns:schedulers="http://www.mulesoft.org/schema/mule/schedulers" xmlns:file="http://www.mulesoft.org/schema/mule/file" xmlns:vm="http://www.mulesoft.org/schema/mule/vm" xmlns:sfdc="http://www.mulesoft.org/schema/mule/sfdc" xmlns:json="http://www.mulesoft.org/schema/mule/json" xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns:scripting="http://www.mulesoft.org/schema/mule/scripting" xmlns:tracking="http://www.mulesoft.org/schema/mule/ee/tracking" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:spring="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd http://www.mulesoft.org/schema/mule/json http://www.mulesoft.org/schema/mule/json/current/mule-json.xsd http://www.mulesoft.org/schema/mule/ee/tracking http://www.mulesoft.org/schema/mule/ee/tracking/current/mule-tracking-ee.xsd http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mule/scripting/current/mule-scripting.xsd http://www.mulesoft.org/schema/mule/sfdc http://www.mulesoft.org/schema/mule/sfdc/current/mule-sfdc.xsd http://www.mulesoft.org/schema/mule/file http://www.mulesoft.org/schema/mule/file/current/mule-file.xsd http://www.mulesoft.org/schema/mule/schedulers http://www.mulesoft.org/schema/mule/schedulers/current/mule-schedulers.xsd">
-
   <flow name="pollseedforpropertiesFlow">
     <poll doc:name="Poll">
-      <!--            <fixed-frequency-scheduler frequency="1" timeUnit="MINUTES"/>-->
       <schedulers:cron-scheduler expression="${cron.timer}"/>
-
       <http:request config-ref="SEED_API" path="/organizations" method="GET" doc:name="HTTP: GET organization id"/>
     </poll>
-
     <json:json-to-object-transformer returnClass="java.lang.Object" doc:name="JSON to Object"/>
     <set-variable variableName="ErrorLog" value="" doc:name="Variable: Declare Error Log"/>
     <set-variable variableName="IndicationLabel" value="${SEED.IndicationLabel}" doc:name="Variable: Store the SEED Indication Label from configuration"/>
@@ -25,8 +21,7 @@
       </otherwise>
     </choice>
     <scripting:component doc:name="Groovy: write date processed to local file">
-      <scripting:script engine="Groovy">
-        <![CDATA[return new Date().format('yyyy-MM-dd HH:mm:ss.SSS');]]></scripting:script>
+      <scripting:script engine="Groovy"><![CDATA[return new Date().format('yyyy-MM-dd HH:mm:ss.SSS');]]></scripting:script>
     </scripting:component>
     <file:outbound-endpoint path="/tmp/oep" outputPattern="lastReadDate.txt" responseTimeout="10000" doc:name="File"/>
     <catch-exception-strategy doc:name="Catch Exception Strategy" doc:description="Exception handling for the C2M listener">
@@ -39,8 +34,7 @@
     <http:request config-ref="SEED_API" path="/labels/filter/?inventory_type=property_view&amp;organization_id=#[flowVars.organization_id]" method="POST" doc:name="HTTP: Get all labels for my organization"/>
     <json:json-to-object-transformer returnClass="java.lang.Object" doc:name="JSON to Object"/>
     <scripting:transformer doc:name="Groovy: only look at properties with the 'Add to Salesforce' Label">
-      <scripting:script engine="Groovy">
-        <![CDATA[return payload.find { it.name == flowVars.IndicationLabel }]]></scripting:script>
+      <scripting:script engine="Groovy"><![CDATA[return payload.find { it.name == flowVars.IndicationLabel }]]></scripting:script>
     </scripting:transformer>
     <foreach collection="#[payload.is_applied]" doc:name="For Each">
       <logger message="Getting details from SEED for property: #[payload]" level="INFO" doc:name="Logger"/>
@@ -103,10 +97,12 @@ return sdf.parse(sdf.format(c.getTime()));
     <choice doc:name="Choice">
       <when expression="#[flowVars.labelNames.contains(flowVars.CompliedStatus) &amp;&amp; !flowVars.labelNames.contains(flowVars.ViolationStatus)]">
         <flow-ref name="QuerySFforContactAndAccount" doc:name="QuerySFforContactAndAccount"/>
+        <flow-ref name="QuerySFforAdminContactAndAccount" doc:name="QuerySFforAdminContactAndAccount"/>
         <flow-ref name="PushPropertytoSalesforce" doc:name="PushPropertytoSalesforce"/>
       </when>
       <when expression="#[flowVars.labelNames.contains(flowVars.ViolationStatus) &amp;&amp; !flowVars.labelNames.contains(flowVars.CompliedStatus)]">
         <flow-ref name="QuerySFforContactAndAccount" doc:name="QuerySFforContactAndAccount"/>
+        <flow-ref name="QuerySFforAdminContactAndAccount" doc:name="QuerySFforAdminContactAndAccount"/>
         <flow-ref name="PushPropertytoSalesforce" doc:name="PushPropertytoSalesforce"/>
       </when>
       <when expression="#[flowVars.labelNames.contains(flowVars.ViolationStatus) &amp;&amp; flowVars.labelNames.contains(flowVars.CompliedStatus)]">
@@ -124,8 +120,6 @@ return sdf.parse(sdf.format(c.getTime()));
   <sub-flow name="QuerySFforContactAndAccount">
     <set-variable variableName="contactEmail" value="#[flowVars.PropertyDetails.state.extra_data[&quot;Email&quot;].trim()]" doc:name="Variable: Contact Email useful for getting SF Account"/>
     <set-variable variableName="ContactName" value="#[flowVars.PropertyDetails.state.extra_data[&quot;On Behalf Of&quot;]]" doc:name="Variable: Contact Name"/>
-    <set-payload value=" #[flowVars.PropertyDetails.state.extra_data.Email.trim()]" doc:name="Set Payload"/>
-
     <sfdc:query-single config-ref="Testbed-Salesforce" query="Select Id, Email, Account.Name from Contact where Email = '#[flowVars.contactEmail]'" doc:name="Salesforce: Call for Contact and Account details"/>
     <choice doc:name="Choice">
       <when expression="#[payload != null]">
@@ -160,7 +154,6 @@ return sdf.parse(sdf.format(c.getTime()));
             <set-variable variableName="SFAccountId" value="#[payload[0].id]" doc:name="Variable: Set the SF Account ID"/>
           </otherwise>
         </choice>
-
       </otherwise>
     </choice>
     <scripting:transformer doc:name="Groovy: map fields to new Contact">
@@ -175,7 +168,59 @@ return sdf.parse(sdf.format(c.getTime()));
       <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;.  \n As a result the SEED property named: [(&quot;  + flowVars.PropertyName + &quot;),  Seed ID: (&quot; + flowVars.PropertyId + &quot;)] will not be updated in Salesforce until the issue is resolved.  Confirm that the SEED 'Organization' field&#160;has an exact match with the Salesforce 'Account Name'. If they do not match then update one so that they do.&quot;]" doc:name="Variable"/>
     </catch-exception-strategy>
   </flow>
-
+  <sub-flow name="QuerySFforAdminContactAndAccount">
+    <set-payload value="#[flowVars.PropertyDetails.state.extra_data[&quot;Property Data Administrator - Email&quot;]]" doc:name="Set Payload: Property Data Administrator &#8211; Email"/>
+    <expression-filter expression="#[payload != null]" doc:name="Expression"/>
+    <set-variable variableName="contactEmail" value="#[payload.trim()]" doc:name="Variable: Contact Email useful for getting SF Account"/>
+    <set-variable variableName="ContactName" value="#[flowVars.PropertyDetails.state.extra_data[&quot;Property Data Administrator&quot;]]" doc:name="Variable: Contact Name"/>
+    <sfdc:query-single config-ref="Testbed-Salesforce" query="Select Id, Email, Account.Name from Contact where Email = '#[flowVars.contactEmail]'" doc:name="Salesforce: Call for Contact and Account details"/>
+    <choice doc:name="Choice">
+      <when expression="#[payload != null]">
+        <set-variable variableName="AdminContactResults" value="#[payload.Id]" doc:name="Variable: Contact details"/>
+      </when>
+      <otherwise>
+        <flow-ref name="CreateAdminContactAndAccount" doc:name="CreateContactAndAccount"/>
+      </otherwise>
+    </choice>
+  </sub-flow>
+  <flow name="CreateAdminContactAndAccount">
+    <set-variable variableName="AccountName" value="#[flowVars.PropertyDetails.state.extra_data[&quot;Organization&quot;].trim()]" doc:name="Variable: SF Account Name"/>
+    <sfdc:query-single config-ref="Testbed-Salesforce" query="Select Id from Account where Name = '#[flowVars.AccountName.replace(&quot;'&quot;, &quot;\\'&quot;)]'" doc:name="Salesforce: Get Account if available"/>
+    <choice doc:name="Choice">
+      <when expression="#[payload != null]">
+        <logger message="Found Account with Name: #[flowVars.AccountName]" level="INFO" doc:name="Logger"/>
+        <set-variable variableName="SFPropertyAdminAccountId" value="#[payload.Id]" doc:name="Variable: SF Account Id"/>
+      </when>
+      <otherwise>
+        <set-variable variableName="DefaultAccountRecordType" value="${salesforce.DefaultAccountType}" doc:name="Variable: Default record type"/>
+        <scripting:transformer doc:name="Groovy: map name and record type to new Account">
+          <scripting:script engine="Groovy" file="AccountToSalesforce.groovy"/>
+        </scripting:transformer>
+        <sfdc:create config-ref="Testbed-Salesforce" type="Account" doc:name="Salesforce: Create a new Account">
+          <sfdc:objects ref="#[payload]"/>
+        </sfdc:create>
+        <choice doc:name="Choice">
+          <when expression="#[payload[0].success == 'false']">
+            <logger message="#['Error: ' +  payload]" level="INFO" doc:name="Logger"/>
+          </when>
+          <otherwise>
+            <set-variable variableName="SFPropertyAdminAccountId" value="#[payload[0].id]" doc:name="Variable: Set the SF Property Admin Account ID"/>
+          </otherwise>
+        </choice>
+      </otherwise>
+    </choice>
+    <scripting:transformer doc:name="Groovy: map fields to new Contact">
+      <scripting:script engine="Groovy" file="ContactToSalesforce.groovy"/>
+    </scripting:transformer>
+    <sfdc:create config-ref="Testbed-Salesforce" type="Contact" doc:name="Salesforce: Create a new SF contact">
+      <sfdc:objects ref="#[payload]"/>
+    </sfdc:create>
+    <set-variable variableName="AdminContactResults" value="#[payload[0].id]" doc:name="Variable: Save the SF Contact Id"/>
+    <catch-exception-strategy doc:name="pollseedforpropertiesCatch_Exception_Strategy">
+      <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;\n \n [Error4] Salesforce Account: '&quot; + flowVars.AccountName + &quot;' with Salesforce Contact email: '&quot; + flowVars.contactEmail + &quot;' aren't already objects in Salesforce but could not be created due to:  ==&gt; &quot; +exception.cause.?message or exception.cause]" doc:name="Variable"/>
+      <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;.  \n As a result the SEED property named: [(&quot;  + flowVars.PropertyName + &quot;),  Seed ID: (&quot; + flowVars.PropertyId + &quot;)] will not be updated in Salesforce until the issue is resolved.  Confirm that the SEED 'Organization' field&#160;has an exact match with the Salesforce 'Account Name'. If they do not match then update one so that they do.&quot;]" doc:name="Variable"/>
+    </catch-exception-strategy>
+  </flow>
   <sub-flow name="PushPropertytoSalesforce">
     <choice doc:name="Choice">
       <when expression="#[flowVars.IsInViolation]">
@@ -189,6 +234,7 @@ Property =
 [
 	Id: propData["Benchmark Salesforce ID"],
 	oei__Contact_Name__c: flowVars["ContactResults"],
+	oei_Property_Data_Administrator__c: flowVars["AdminContactResults"],
 	oei__Status__c: flowVars["IsInViolation"] ? flowVars["ViolationStatus"] : flowVars["CompliedStatus"],
 	oei__SEED_Labels__c: flowVars["labelNameString"]
 ]

--- a/SEED Benchmark/OEI/classes/pollseedforproperties.xml
+++ b/SEED Benchmark/OEI/classes/pollseedforproperties.xml
@@ -1,24 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<mule xmlns:schedulers="http://www.mulesoft.org/schema/mule/schedulers"
-      xmlns:file="http://www.mulesoft.org/schema/mule/file" xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
-      xmlns:sfdc="http://www.mulesoft.org/schema/mule/sfdc" xmlns:json="http://www.mulesoft.org/schema/mule/json"
-      xmlns:http="http://www.mulesoft.org/schema/mule/http"
-      xmlns:scripting="http://www.mulesoft.org/schema/mule/scripting"
-      xmlns:tracking="http://www.mulesoft.org/schema/mule/ee/tracking" xmlns="http://www.mulesoft.org/schema/mule/core"
-      xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
-      xmlns:spring="http://www.springframework.org/schema/beans"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
-http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
-http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
-http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
-http://www.mulesoft.org/schema/mule/json http://www.mulesoft.org/schema/mule/json/current/mule-json.xsd
-http://www.mulesoft.org/schema/mule/ee/tracking http://www.mulesoft.org/schema/mule/ee/tracking/current/mule-tracking-ee.xsd
-http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mule/scripting/current/mule-scripting.xsd
-http://www.mulesoft.org/schema/mule/sfdc http://www.mulesoft.org/schema/mule/sfdc/current/mule-sfdc.xsd
-http://www.mulesoft.org/schema/mule/file http://www.mulesoft.org/schema/mule/file/current/mule-file.xsd
-http://www.mulesoft.org/schema/mule/schedulers http://www.mulesoft.org/schema/mule/schedulers/current/mule-schedulers.xsd">
+<mule xmlns:schedulers="http://www.mulesoft.org/schema/mule/schedulers" xmlns:file="http://www.mulesoft.org/schema/mule/file" xmlns:vm="http://www.mulesoft.org/schema/mule/vm" xmlns:sfdc="http://www.mulesoft.org/schema/mule/sfdc" xmlns:json="http://www.mulesoft.org/schema/mule/json" xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns:scripting="http://www.mulesoft.org/schema/mule/scripting" xmlns:tracking="http://www.mulesoft.org/schema/mule/ee/tracking" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:spring="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd http://www.mulesoft.org/schema/mule/json http://www.mulesoft.org/schema/mule/json/current/mule-json.xsd http://www.mulesoft.org/schema/mule/ee/tracking http://www.mulesoft.org/schema/mule/ee/tracking/current/mule-tracking-ee.xsd http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mule/scripting/current/mule-scripting.xsd http://www.mulesoft.org/schema/mule/sfdc http://www.mulesoft.org/schema/mule/sfdc/current/mule-sfdc.xsd http://www.mulesoft.org/schema/mule/file http://www.mulesoft.org/schema/mule/file/current/mule-file.xsd http://www.mulesoft.org/schema/mule/schedulers http://www.mulesoft.org/schema/mule/schedulers/current/mule-schedulers.xsd">
 
   <flow name="pollseedforpropertiesFlow">
     <poll doc:name="Poll">
@@ -30,8 +10,7 @@ http://www.mulesoft.org/schema/mule/schedulers http://www.mulesoft.org/schema/mu
 
     <json:json-to-object-transformer returnClass="java.lang.Object" doc:name="JSON to Object"/>
     <set-variable variableName="ErrorLog" value="" doc:name="Variable: Declare Error Log"/>
-    <set-variable variableName="IndicationLabel" value="${SEED.IndicationLabel}"
-                  doc:name="Variable: Store the SEED Indication Label from configuration"/>
+    <set-variable variableName="IndicationLabel" value="${SEED.IndicationLabel}" doc:name="Variable: Store the SEED Indication Label from configuration"/>
     <foreach collection="#[payload.organizations]" doc:name="For Each">
       <set-variable variableName="organization_id" value="#[payload.org_id]" doc:name="Variable"/>
       <logger message="Calling for properties for Org ID: #[flowVars.organization_id]" level="INFO" doc:name="Logger"/>
@@ -50,21 +29,14 @@ http://www.mulesoft.org/schema/mule/schedulers http://www.mulesoft.org/schema/mu
         <![CDATA[return new Date().format('yyyy-MM-dd HH:mm:ss.SSS');]]></scripting:script>
     </scripting:component>
     <file:outbound-endpoint path="/tmp/oep" outputPattern="lastReadDate.txt" responseTimeout="10000" doc:name="File"/>
-    <catch-exception-strategy doc:name="Catch Exception Strategy"
-                              doc:description="Exception handling for the C2M listener">
-      <set-variable variableName="ErrorLog"
-                    value="#[flowVars.ErrorLog + &quot;\n \n [Info1] &quot; + exception.getEvent() + &quot;with the following details: \n&quot; + exception.getCauseException()]"
-                    doc:name="Variable: Update Error Log"/>
+    <catch-exception-strategy doc:name="Catch Exception Strategy" doc:description="Exception handling for the C2M listener">
+      <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;\n \n [Info1] &quot; + exception.getEvent() + &quot;with the following details: \n&quot; + exception.getCauseException()]" doc:name="Variable: Update Error Log"/>
       <flow-ref name="ErrorHandler" doc:name="ErrorHandler"/>
     </catch-exception-strategy>
   </flow>
   <flow name="getpropertiesfororg" processingStrategy="synchronous">
-    <set-variable variableName="SeedPath"
-                  value="/labels/filter/?inventory_type=property_view&amp;organization_id=#[flowVars.organization_id]"
-                  doc:name="Variable"/>
-    <http:request config-ref="SEED_API"
-                  path="/labels/filter/?inventory_type=property_view&amp;organization_id=#[flowVars.organization_id]"
-                  method="POST" doc:name="HTTP: Get all labels for my organization"/>
+    <set-variable variableName="SeedPath" value="/labels/filter/?inventory_type=property_view&amp;organization_id=#[flowVars.organization_id]" doc:name="Variable"/>
+    <http:request config-ref="SEED_API" path="/labels/filter/?inventory_type=property_view&amp;organization_id=#[flowVars.organization_id]" method="POST" doc:name="HTTP: Get all labels for my organization"/>
     <json:json-to-object-transformer returnClass="java.lang.Object" doc:name="JSON to Object"/>
     <scripting:transformer doc:name="Groovy: only look at properties with the 'Add to Salesforce' Label">
       <scripting:script engine="Groovy">
@@ -75,22 +47,17 @@ http://www.mulesoft.org/schema/mule/schedulers http://www.mulesoft.org/schema/mu
       <flow-ref name="GetPropertyDetailsFromSEED" doc:name="GetPropertyDetailsFromSEED"/>
     </foreach>
     <catch-exception-strategy doc:name="Catch Exception Strategy">
-      <set-variable variableName="ErrorLog"
-                    value="#['Calling ' + ${SEED.url}  + flowVars.SeedPath + ' resulted in the response:  \n \n ' + message.payloadAs(java.lang.String)]"
-                    doc:name="Variable"/>
+      <set-variable variableName="ErrorLog" value="#['Calling ' + ${SEED.url}  + flowVars.SeedPath + ' resulted in the response:  \n \n ' + message.payloadAs(java.lang.String)]" doc:name="Variable"/>
       <flow-ref name="ErrorHandler" doc:name="Flow Reference"/>
     </catch-exception-strategy>
   </flow>
   <flow name="GetPropertyDetailsFromSEED">
     <set-variable variableName="PropertyId" value="#[payload]" doc:name="Variable: SEED Property Id"/>
-    <http:request config-ref="SEED_API" path="/properties/#[payload]/?organization_id=#[flowVars.organization_id]"
-                  method="GET" doc:name="HTTP: Call for Details"/>
+    <http:request config-ref="SEED_API" path="/properties/#[payload]/?organization_id=#[flowVars.organization_id]" method="GET" doc:name="HTTP: Call for Details"/>
     <json:json-to-object-transformer returnClass="java.lang.Object" doc:name="JSON to Object"/>
     <set-variable variableName="PropertyDetails" value="#[payload]" doc:name="Variable: Property Details"/>
-    <set-variable variableName="PropertyName" value="#[flowVars.PropertyDetails.state.property_name]"
-                  doc:name="Variable: SEED Property Name"/>
-    <set-variable variableName="updatedDate" value="#[flowVars.PropertyDetails.property.updated]"
-                  doc:name="Variable: Get Updated Date"/>
+    <set-variable variableName="PropertyName" value="#[flowVars.PropertyDetails.state.property_name]" doc:name="Variable: SEED Property Name"/>
+    <set-variable variableName="updatedDate" value="#[flowVars.PropertyDetails.property.updated]" doc:name="Variable: Get Updated Date"/>
     <scripting:component doc:name="Groovy: get the last processed dates for comparison ">
       <scripting:script engine="Groovy"><![CDATA[import java.util.GregorianCalendar;
 import java.util.Calendar;
@@ -115,10 +82,8 @@ return sdf.parse(sdf.format(c.getTime()));
 
 ]]></scripting:script>
     </scripting:component>
-    <expression-filter expression="#[flowVars.seedDate &gt; payload]"
-                       doc:name="Expression: Filter anything not recently updated"/>
-    <logger message="Getting details for labels from Property: #[flowVars.PropertyDetails.property.id]" level="INFO"
-            doc:name="Logger"/>
+    <expression-filter expression="#[flowVars.seedDate &gt; payload]" doc:name="Expression: Filter anything not recently updated"/>
+    <logger message="Getting details for labels from Property: #[flowVars.PropertyDetails.property.id]" level="INFO" doc:name="Logger"/>
     <set-variable variableName="labelNames" value="#[[]]" doc:name="Variable: Array of Label Names"/>
     <set-payload value=" #[flowVars.PropertyDetails.labels]" mimeType="application/json" doc:name="Set Payload"/>
     <json:json-to-object-transformer returnClass="java.lang.Object" doc:name="JSON to Object"/>
@@ -126,65 +91,42 @@ return sdf.parse(sdf.format(c.getTime()));
       <set-variable variableName="LabelID" value="#[payload]" doc:name="Variable"/>
       <http:request config-ref="SEED_API" path="/labels/#[payload]" method="GET" doc:name="HTTP: Get label name"/>
       <json:json-to-object-transformer returnClass="java.lang.Object" doc:name="JSON to Object"/>
-      <expression-transformer
-      expression="#[payload != null ? flowVars.labelNames.add(payload.name) : flowVars.labelNames ]"
-      doc:name="Expression: Add the label name to the collection"/>
+      <expression-transformer expression="#[payload != null ? flowVars.labelNames.add(payload.name) : flowVars.labelNames ]" doc:name="Expression: Add the label name to the collection"/>
     </foreach>
-    <set-variable variableName="ViolationStatus" value="${SEED.ViolationLabel}"
-                  doc:name="Variable: Set Violation Text"/>
+    <set-variable variableName="ViolationStatus" value="${SEED.ViolationLabel}" doc:name="Variable: Set Violation Text"/>
     <set-variable variableName="CompliedStatus" value="${SEED.CompliedLabel}" doc:name="Variable: Set Complied Text"/>
-    <set-variable variableName="IsInViolation"
-                  value="#[flowVars.labelNames.contains(flowVars.ViolationStatus) ? true : false]"
-                  doc:name="Variable: Does this property Comply?"/>
+    <set-variable variableName="IsInViolation" value="#[flowVars.labelNames.contains(flowVars.ViolationStatus) ? true : false]" doc:name="Variable: Does this property Comply?"/>
     <scripting:transformer doc:name="Flatten List of label names">
       <scripting:script engine="Groovy"><![CDATA[return flowVars.labelNames.join("; ")]]></scripting:script>
     </scripting:transformer>
-    <set-variable variableName="labelNameString" value="#[payload]"
-                  doc:name="Variable: Keep semicolon separated list of label names for later"/>
+    <set-variable variableName="labelNameString" value="#[payload]" doc:name="Variable: Keep semicolon separated list of label names for later"/>
     <choice doc:name="Choice">
-      <when
-      expression="#[flowVars.labelNames.contains(flowVars.CompliedStatus) &amp;&amp; !flowVars.labelNames.contains(flowVars.ViolationStatus)]">
+      <when expression="#[flowVars.labelNames.contains(flowVars.CompliedStatus) &amp;&amp; !flowVars.labelNames.contains(flowVars.ViolationStatus)]">
         <flow-ref name="QuerySFforContactAndAccount" doc:name="QuerySFforContactAndAccount"/>
         <flow-ref name="PushPropertytoSalesforce" doc:name="PushPropertytoSalesforce"/>
       </when>
-      <when
-      expression="#[flowVars.labelNames.contains(flowVars.ViolationStatus) &amp;&amp; !flowVars.labelNames.contains(flowVars.CompliedStatus)]">
+      <when expression="#[flowVars.labelNames.contains(flowVars.ViolationStatus) &amp;&amp; !flowVars.labelNames.contains(flowVars.CompliedStatus)]">
         <flow-ref name="QuerySFforContactAndAccount" doc:name="QuerySFforContactAndAccount"/>
         <flow-ref name="PushPropertytoSalesforce" doc:name="PushPropertytoSalesforce"/>
       </when>
-      <when
-      expression="#[flowVars.labelNames.contains(flowVars.ViolationStatus) &amp;&amp; flowVars.labelNames.contains(flowVars.CompliedStatus)]">
-        <set-variable variableName="ErrorLog"
-                      value="#[flowVars.ErrorLog + &quot;\n \n [Error1] SEED property: &quot; + flowVars.PropertyDetails.state.property_name + &quot;, SEED Id: &quot; + flowVars.PropertyId + &quot;. Both '&quot; + flowVars.CompliedStatus + &quot;' AND '&quot; + flowVars.ViolationStatus + &quot;' labels have been applied to this property so no action will be taken.&quot; ]"
-                      doc:name="Variable: Error Log (both Complied and Violation statuses exist)"/>
+      <when expression="#[flowVars.labelNames.contains(flowVars.ViolationStatus) &amp;&amp; flowVars.labelNames.contains(flowVars.CompliedStatus)]">
+        <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;\n \n [Error1] SEED property: &quot; + flowVars.PropertyDetails.state.property_name + &quot;, SEED Id: &quot; + flowVars.PropertyId + &quot;. Both '&quot; + flowVars.CompliedStatus + &quot;' AND '&quot; + flowVars.ViolationStatus + &quot;' labels have been applied to this property so no action will be taken.&quot; ]" doc:name="Variable: Error Log (both Complied and Violation statuses exist)"/>
       </when>
       <otherwise>
-        <set-variable variableName="ErrorLog"
-                      value="#[flowVars.ErrorLog + &quot;\n \n [Error1] SEED property: &quot; + flowVars.PropertyDetails.state.property_name + &quot;, SEED Id: &quot; + flowVars.PropertyId + &quot;. Neither '&quot; + flowVars.CompliedStatus + &quot;' or '&quot; + flowVars.ViolationStatus + &quot;' labels have been applied to this property so no action will be taken.&quot; ]"
-                      doc:name="Variable: Error Log"/>
+        <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;\n \n [Error1] SEED property: &quot; + flowVars.PropertyDetails.state.property_name + &quot;, SEED Id: &quot; + flowVars.PropertyId + &quot;. Neither '&quot; + flowVars.CompliedStatus + &quot;' or '&quot; + flowVars.ViolationStatus + &quot;' labels have been applied to this property so no action will be taken.&quot; ]" doc:name="Variable: Error Log"/>
       </otherwise>
     </choice>
     <catch-exception-strategy doc:name="pollseedforpropertiesCatch_Exception_Strategy">
-      <set-variable variableName="ErrorLog"
-                    value="#[flowVars.ErrorLog + &quot;\n \n [Error4] SEED Label: '&quot; + flowVars.LabelID + &quot;' assigned to Property: &quot; + flowVars.PropertyName + &quot; has no details in SEED. &quot;]"
-                    doc:name="Variable"/>
-      <set-variable variableName="ErrorLog"
-                    value="#[flowVars.ErrorLog + &quot;.  \n As a result the SEED property named: [(&quot;  + flowVars.PropertyName + &quot;),  Seed ID: (&quot; + flowVars.PropertyId + &quot;)] will not be updated in Salesforce until the issue is resolved.  Confirm that the unavailable SEED label is removed from this property.&quot;]"
-                    doc:name="Variable"/>
+      <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;\n \n [Error4] SEED Label: '&quot; + flowVars.LabelID + &quot;' assigned to Property: &quot; + flowVars.PropertyName + &quot; has no details in SEED. &quot;]" doc:name="Variable"/>
+      <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;.  \n As a result the SEED property named: [(&quot;  + flowVars.PropertyName + &quot;),  Seed ID: (&quot; + flowVars.PropertyId + &quot;)] will not be updated in Salesforce until the issue is resolved.  Confirm that the unavailable SEED label is removed from this property.&quot;]" doc:name="Variable"/>
     </catch-exception-strategy>
   </flow>
   <sub-flow name="QuerySFforContactAndAccount">
-    <set-variable variableName="contactEmail"
-                  value="#[flowVars.PropertyDetails.state.extra_data[&quot;Email&quot;].trim()]"
-                  doc:name="Variable: Contact Email useful for getting SF Account"/>
-    <set-variable variableName="ContactName"
-                  value="#[flowVars.PropertyDetails.state.extra_data[&quot;On Behalf Of&quot;]]"
-                  doc:name="Variable: Contact Name"/>
+    <set-variable variableName="contactEmail" value="#[flowVars.PropertyDetails.state.extra_data[&quot;Email&quot;].trim()]" doc:name="Variable: Contact Email useful for getting SF Account"/>
+    <set-variable variableName="ContactName" value="#[flowVars.PropertyDetails.state.extra_data[&quot;On Behalf Of&quot;]]" doc:name="Variable: Contact Name"/>
     <set-payload value=" #[flowVars.PropertyDetails.state.extra_data.Email.trim()]" doc:name="Set Payload"/>
 
-    <sfdc:query-single config-ref="Testbed-Salesforce"
-                       query="Select Id, Email, Account.Name from Contact where Email = '#[flowVars.contactEmail]'"
-                       doc:name="Salesforce: Call for Contact and Account details"/>
+    <sfdc:query-single config-ref="Testbed-Salesforce" query="Select Id, Email, Account.Name from Contact where Email = '#[flowVars.contactEmail]'" doc:name="Salesforce: Call for Contact and Account details"/>
     <choice doc:name="Choice">
       <when expression="#[payload != null]">
         <set-variable variableName="ContactResults" value="#[payload.Id]" doc:name="Variable: Contact details"/>
@@ -195,20 +137,15 @@ return sdf.parse(sdf.format(c.getTime()));
     </choice>
   </sub-flow>
   <flow name="CreateContactAndAccount">
-    <set-variable variableName="AccountName"
-                  value="#[flowVars.PropertyDetails.state.extra_data[&quot;Organization&quot;].trim()]"
-                  doc:name="Variable: SF Account Name"/>
-    <sfdc:query-single config-ref="Testbed-Salesforce"
-                       query="Select Id from Account where Name = '#[flowVars.AccountName.replace(&quot;'&quot;, &quot;\\'&quot;)]'"
-                       doc:name="Salesforce: Get Account if available"/>
+    <set-variable variableName="AccountName" value="#[flowVars.PropertyDetails.state.extra_data[&quot;Organization&quot;].trim()]" doc:name="Variable: SF Account Name"/>
+    <sfdc:query-single config-ref="Testbed-Salesforce" query="Select Id from Account where Name = '#[flowVars.AccountName.replace(&quot;'&quot;, &quot;\\'&quot;)]'" doc:name="Salesforce: Get Account if available"/>
     <choice doc:name="Choice">
       <when expression="#[payload != null]">
         <logger message="Found Account with Name: #[flowVars.AccountName]" level="INFO" doc:name="Logger"/>
         <set-variable variableName="SFAccountId" value="#[payload.Id]" doc:name="Variable: SF Account Id"/>
       </when>
       <otherwise>
-        <set-variable variableName="DefaultAccountRecordType" value="${salesforce.DefaultAccountType}"
-                      doc:name="Variable: Default record type"/>
+        <set-variable variableName="DefaultAccountRecordType" value="${salesforce.DefaultAccountType}" doc:name="Variable: Default record type"/>
         <scripting:transformer doc:name="Groovy: map name and record type to new Account">
           <scripting:script engine="Groovy" file="AccountToSalesforce.groovy"/>
         </scripting:transformer>
@@ -220,8 +157,7 @@ return sdf.parse(sdf.format(c.getTime()));
             <logger message="#['Error: ' +  payload]" level="INFO" doc:name="Logger"/>
           </when>
           <otherwise>
-            <set-variable variableName="SFAccountId" value="#[payload[0].id]"
-                          doc:name="Variable: Set the SF Account ID"/>
+            <set-variable variableName="SFAccountId" value="#[payload[0].id]" doc:name="Variable: Set the SF Account ID"/>
           </otherwise>
         </choice>
 
@@ -235,12 +171,8 @@ return sdf.parse(sdf.format(c.getTime()));
     </sfdc:create>
     <set-variable variableName="ContactResults" value="#[payload[0].id]" doc:name="Variable: Save the SF Contact Id"/>
     <catch-exception-strategy doc:name="pollseedforpropertiesCatch_Exception_Strategy">
-      <set-variable variableName="ErrorLog"
-                    value="#[flowVars.ErrorLog + &quot;\n \n [Error4] Salesforce Account: '&quot; + flowVars.AccountName + &quot;' with Salesforce Contact email: '&quot; + flowVars.contactEmail + &quot;' aren't already objects in Salesforce but could not be created due to:  ==&gt; &quot; +exception.cause.?message or exception.cause]"
-                    doc:name="Variable"/>
-      <set-variable variableName="ErrorLog"
-                    value="#[flowVars.ErrorLog + &quot;.  \n As a result the SEED property named: [(&quot;  + flowVars.PropertyName + &quot;),  Seed ID: (&quot; + flowVars.PropertyId + &quot;)] will not be updated in Salesforce until the issue is resolved.  Confirm that the SEED 'Organization' field&#160;has an exact match with the Salesforce 'Account Name'. If they do not match then update one so that they do.&quot;]"
-                    doc:name="Variable"/>
+      <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;\n \n [Error4] Salesforce Account: '&quot; + flowVars.AccountName + &quot;' with Salesforce Contact email: '&quot; + flowVars.contactEmail + &quot;' aren't already objects in Salesforce but could not be created due to:  ==&gt; &quot; +exception.cause.?message or exception.cause]" doc:name="Variable"/>
+      <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;.  \n As a result the SEED property named: [(&quot;  + flowVars.PropertyName + &quot;),  Seed ID: (&quot; + flowVars.PropertyId + &quot;)] will not be updated in Salesforce until the issue is resolved.  Confirm that the SEED 'Organization' field&#160;has an exact match with the Salesforce 'Account Name'. If they do not match then update one so that they do.&quot;]" doc:name="Variable"/>
     </catch-exception-strategy>
   </flow>
 
@@ -272,9 +204,7 @@ return [Property]]]></scripting:script>
     </choice>
     <choice doc:name="Choice">
       <when expression="#[flowVars.SFPremiseId == '' || flowVars.SFPremiseId == null]">
-        <set-variable variableName="ErrorLog"
-                      value="#[flowVars.ErrorLog + &quot;\n \n [Error2] SEED property: &quot; + flowVars.PropertyDetails.state.property_name + &quot;, SEED property ID: &quot; + flowVars.PropertyId + &quot; 'Benchmark Salesforce ID' field is missing, there is no Salesforce object destination so no action will be taken.&quot;]"
-                      doc:name="Variable: update ErrorLog"/>
+        <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;\n \n [Error2] SEED property: &quot; + flowVars.PropertyDetails.state.property_name + &quot;, SEED property ID: &quot; + flowVars.PropertyId + &quot; 'Benchmark Salesforce ID' field is missing, there is no Salesforce object destination so no action will be taken.&quot;]" doc:name="Variable: update ErrorLog"/>
       </when>
       <otherwise>
         <sfdc:update config-ref="Testbed-Salesforce" type="oei__Benchmark__c" doc:name="Salesforce: Update Benchmark">
@@ -282,9 +212,7 @@ return [Property]]]></scripting:script>
         </sfdc:update>
         <choice doc:name="Choice">
           <when expression="#[payload[0].success == 'false']">
-            <set-variable variableName="ErrorLog"
-                          value="#[flowVars.ErrorLog + &quot;\n \n [Error3] For SEED property: &quot; + flowVars.PropertyDetails.state.property_name + &quot;, SEED Id: &quot; + flowVars.PropertyId + &quot; There was an error when updating Salesforce, which returned the following message: \n &quot; + payload[0].wrapped.errors[0].message]"
-                          doc:name="Variable: Update Error Log"/>
+            <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;\n \n [Error3] For SEED property: &quot; + flowVars.PropertyDetails.state.property_name + &quot;, SEED Id: &quot; + flowVars.PropertyId + &quot; There was an error when updating Salesforce, which returned the following message: \n &quot; + payload[0].wrapped.errors[0].message]" doc:name="Variable: Update Error Log"/>
           </when>
           <otherwise>
             <logger message="#[payload]" level="INFO" doc:name="Logger"/>

--- a/SEED Benchmark/OEI/global.xml
+++ b/SEED Benchmark/OEI/global.xml
@@ -1,31 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:context="http://www.springframework.org/schema/context"
-      xmlns:cxf="http://www.mulesoft.org/schema/mule/cxf" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
-      xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns:https="http://www.mulesoft.org/schema/mule/https"
-      xmlns:json="http://www.mulesoft.org/schema/mule/json"
-      xmlns:metadata="http://www.mulesoft.org/schema/mule/metadata"
-      xmlns:mule-ss="http://www.mulesoft.org/schema/mule/spring-security"
-      xmlns:sfdc="http://www.mulesoft.org/schema/mule/sfdc" xmlns:sftp="http://www.mulesoft.org/schema/mule/sftp"
-      xmlns:smtp="http://www.mulesoft.org/schema/mule/smtp" xmlns:spring="http://www.springframework.org/schema/beans"
-      xmlns:ss="http://www.springframework.org/schema/security" xmlns:tls="http://www.mulesoft.org/schema/mule/tls"
-      xmlns:tracking="http://www.mulesoft.org/schema/mule/ee/tracking" xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/sfdc http://www.mulesoft.org/schema/mule/sfdc/current/mule-sfdc.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-current.xsd http://www.mulesoft.org/schema/mule/https http://www.mulesoft.org/schema/mule/https/current/mule-https.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd http://www.mulesoft.org/schema/mule/cxf http://www.mulesoft.org/schema/mule/cxf/current/mule-cxf.xsd http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd http://www.mulesoft.org/schema/mule/ee/tracking http://www.mulesoft.org/schema/mule/ee/tracking/current/mule-tracking-ee.xsd http://www.mulesoft.org/schema/mule/smtp http://www.mulesoft.org/schema/mule/smtp/current/mule-smtp.xsd http://www.mulesoft.org/schema/mule/tls http://www.mulesoft.org/schema/mule/tls/current/mule-tls.xsd http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.0.xsd http://www.mulesoft.org/schema/mule/spring-security http://www.mulesoft.org/schema/mule/spring-security/3.8/mule-spring-security.xsd http://www.mulesoft.org/schema/mule/json http://www.mulesoft.org/schema/mule/json/current/mule-json.xsd http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd">
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:context="http://www.springframework.org/schema/context" xmlns:cxf="http://www.mulesoft.org/schema/mule/cxf" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns:https="http://www.mulesoft.org/schema/mule/https" xmlns:json="http://www.mulesoft.org/schema/mule/json" xmlns:metadata="http://www.mulesoft.org/schema/mule/metadata" xmlns:mule-ss="http://www.mulesoft.org/schema/mule/spring-security" xmlns:sfdc="http://www.mulesoft.org/schema/mule/sfdc" xmlns:sftp="http://www.mulesoft.org/schema/mule/sftp" xmlns:smtp="http://www.mulesoft.org/schema/mule/smtp" xmlns:spring="http://www.springframework.org/schema/beans" xmlns:ss="http://www.springframework.org/schema/security" xmlns:tls="http://www.mulesoft.org/schema/mule/tls" xmlns:tracking="http://www.mulesoft.org/schema/mule/ee/tracking" xmlns:vm="http://www.mulesoft.org/schema/mule/vm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/sfdc http://www.mulesoft.org/schema/mule/sfdc/current/mule-sfdc.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-current.xsd http://www.mulesoft.org/schema/mule/https http://www.mulesoft.org/schema/mule/https/current/mule-https.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd http://www.mulesoft.org/schema/mule/cxf http://www.mulesoft.org/schema/mule/cxf/current/mule-cxf.xsd http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd http://www.mulesoft.org/schema/mule/ee/tracking http://www.mulesoft.org/schema/mule/ee/tracking/current/mule-tracking-ee.xsd http://www.mulesoft.org/schema/mule/smtp http://www.mulesoft.org/schema/mule/smtp/current/mule-smtp.xsd http://www.mulesoft.org/schema/mule/tls http://www.mulesoft.org/schema/mule/tls/current/mule-tls.xsd http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.0.xsd http://www.mulesoft.org/schema/mule/spring-security http://www.mulesoft.org/schema/mule/spring-security/3.8/mule-spring-security.xsd http://www.mulesoft.org/schema/mule/json http://www.mulesoft.org/schema/mule/json/current/mule-json.xsd http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd">
   <spring:beans>
     <spring:bean class="org.mule.util.store.SimpleMemoryObjectStore" id="objectStore"/>
   </spring:beans>
   <context:property-placeholder location="oei.properties"/>
   <vm:endpoint doc:name="VM" exchange-pattern="one-way" name="VM.DLQ" path="deadletterqueue"/>
-  <queued-asynchronous-processing-strategy doc:name="Queued Asynchronous Processing Strategy" maxThreads="1"
-                                           name="Queued_Asynchronous_Processing_Strategy"/>
-  <cxf:configuration doc:name="CXF Configuration" enableMuleSoapHeaders="true" initializeStaticBusInstance="true"
-                     name="CXF_Configuration"/>
-  <sfdc:config doc:name="Salesforce" name="Testbed-Salesforce" password="${salesforce.password}"
-               securityToken="${salesforce.token}" url="${salesforce.url}" username="${salesforce.user}">
+  <queued-asynchronous-processing-strategy doc:name="Queued Asynchronous Processing Strategy" maxThreads="1" name="Queued_Asynchronous_Processing_Strategy"/>
+  <cxf:configuration doc:name="CXF Configuration" enableMuleSoapHeaders="true" initializeStaticBusInstance="true" name="CXF_Configuration"/>
+  <sfdc:config doc:name="Salesforce" name="Testbed-Salesforce" password="${salesforce.password}" securityToken="${salesforce.token}" url="${salesforce.url}" username="${salesforce.user}">
     <sfdc:connection-pooling-profile exhaustedAction="WHEN_EXHAUSTED_GROW" initialisationPolicy="INITIALISE_ONE"/>
   </sfdc:config>
-  <http:request-config basePath="/api/v2" doc:name="HTTP Request Configuration" host="${SEED.url}" name="SEED_API"
-                       port="${SEED.port}" protocol="${SEED.protocol}">
+  <http:request-config basePath="/api/v2" doc:name="HTTP Request Configuration" host="${SEED.url}" name="SEED_API" port="${SEED.port}" protocol="${SEED.protocol}">
     <http:basic-authentication password="${SEED.apikey}" preemptive="true" username="${SEED.user}"/>
   </http:request-config>
   <flow name="DeadLetterFlow">
@@ -34,16 +18,13 @@
     <choice doc:name="Choice">
       <when expression="#[exception.causedBy(org.mule.routing.CompositeRoutingException)]">
         <foreach collection="#[exception.getExceptions().values()]" doc:name="For Each">
-          <logger doc:name="Logger" level="INFO"
-                  message="#[groovy: new com.psdconsulting.RootException(payload).toString()]"/>
+          <logger doc:name="Logger" level="INFO" message="#[groovy: new com.psdconsulting.RootException(payload).toString()]"/>
         </foreach>
       </when>
       <otherwise>
         <logger doc:name="Logger" level="INFO" message="Exception: #[exception]"/>
       </otherwise>
     </choice>
-    <smtp:outbound-endpoint doc:name="SMTP" from="${email.sender}" host="${email.host}" password="${email.password}"
-                            responseTimeout="10000" subject="${email.subject}" to="${email.recipient}"
-                            user="${email.user}"/>
+    <smtp:outbound-endpoint doc:name="SMTP" from="${email.sender}" host="${email.host}" password="${email.password}" responseTimeout="10000" subject="${email.subject}" to="${email.recipient}" user="${email.user}"/>
   </flow>
 </mule>

--- a/SEED Benchmark/OEI/global.xml
+++ b/SEED Benchmark/OEI/global.xml
@@ -9,7 +9,7 @@
   <sfdc:config doc:name="Salesforce" name="Testbed-Salesforce" password="${salesforce.password}" securityToken="${salesforce.token}" url="${salesforce.url}" username="${salesforce.user}">
     <sfdc:connection-pooling-profile exhaustedAction="WHEN_EXHAUSTED_GROW" initialisationPolicy="INITIALISE_ONE"/>
   </sfdc:config>
-  <http:request-config basePath="/api/v2" doc:name="HTTP Request Configuration" host="${SEED.url}" name="SEED_API" port="${SEED.port}" protocol="${SEED.protocol}">
+  <http:request-config basePath="/api/${SEED.apiversion}" doc:name="HTTP Request Configuration" host="${SEED.url}" name="SEED_API" port="${SEED.port}" protocol="${SEED.protocol}">
     <http:basic-authentication password="${SEED.apikey}" preemptive="true" username="${SEED.user}"/>
   </http:request-config>
   <flow name="DeadLetterFlow">

--- a/SEED Benchmark/OEI/pollseedforproperties.xml
+++ b/SEED Benchmark/OEI/pollseedforproperties.xml
@@ -1,13 +1,9 @@
 <mule xmlns:schedulers="http://www.mulesoft.org/schema/mule/schedulers" xmlns:file="http://www.mulesoft.org/schema/mule/file" xmlns:vm="http://www.mulesoft.org/schema/mule/vm" xmlns:sfdc="http://www.mulesoft.org/schema/mule/sfdc" xmlns:json="http://www.mulesoft.org/schema/mule/json" xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns:scripting="http://www.mulesoft.org/schema/mule/scripting" xmlns:tracking="http://www.mulesoft.org/schema/mule/ee/tracking" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:spring="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd http://www.mulesoft.org/schema/mule/json http://www.mulesoft.org/schema/mule/json/current/mule-json.xsd http://www.mulesoft.org/schema/mule/ee/tracking http://www.mulesoft.org/schema/mule/ee/tracking/current/mule-tracking-ee.xsd http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mule/scripting/current/mule-scripting.xsd http://www.mulesoft.org/schema/mule/sfdc http://www.mulesoft.org/schema/mule/sfdc/current/mule-sfdc.xsd http://www.mulesoft.org/schema/mule/file http://www.mulesoft.org/schema/mule/file/current/mule-file.xsd http://www.mulesoft.org/schema/mule/schedulers http://www.mulesoft.org/schema/mule/schedulers/current/mule-schedulers.xsd">
-
   <flow name="pollseedforpropertiesFlow">
     <poll doc:name="Poll">
-      <!--            <fixed-frequency-scheduler frequency="1" timeUnit="MINUTES"/>-->
       <schedulers:cron-scheduler expression="${cron.timer}"/>
-
       <http:request config-ref="SEED_API" path="/organizations" method="GET" doc:name="HTTP: GET organization id"/>
     </poll>
-
     <json:json-to-object-transformer returnClass="java.lang.Object" doc:name="JSON to Object"/>
     <set-variable variableName="ErrorLog" value="" doc:name="Variable: Declare Error Log"/>
     <set-variable variableName="IndicationLabel" value="${SEED.IndicationLabel}" doc:name="Variable: Store the SEED Indication Label from configuration"/>
@@ -25,8 +21,7 @@
       </otherwise>
     </choice>
     <scripting:component doc:name="Groovy: write date processed to local file">
-      <scripting:script engine="Groovy">
-        <![CDATA[return new Date().format('yyyy-MM-dd HH:mm:ss.SSS');]]></scripting:script>
+      <scripting:script engine="Groovy"><![CDATA[return new Date().format('yyyy-MM-dd HH:mm:ss.SSS');]]></scripting:script>
     </scripting:component>
     <file:outbound-endpoint path="/tmp/oep" outputPattern="lastReadDate.txt" responseTimeout="10000" doc:name="File"/>
     <catch-exception-strategy doc:name="Catch Exception Strategy" doc:description="Exception handling for the C2M listener">
@@ -39,8 +34,7 @@
     <http:request config-ref="SEED_API" path="/labels/filter/?inventory_type=property_view&amp;organization_id=#[flowVars.organization_id]" method="POST" doc:name="HTTP: Get all labels for my organization"/>
     <json:json-to-object-transformer returnClass="java.lang.Object" doc:name="JSON to Object"/>
     <scripting:transformer doc:name="Groovy: only look at properties with the 'Add to Salesforce' Label">
-      <scripting:script engine="Groovy">
-        <![CDATA[return payload.find { it.name == flowVars.IndicationLabel }]]></scripting:script>
+      <scripting:script engine="Groovy"><![CDATA[return payload.find { it.name == flowVars.IndicationLabel }]]></scripting:script>
     </scripting:transformer>
     <foreach collection="#[payload.is_applied]" doc:name="For Each">
       <logger message="Getting details from SEED for property: #[payload]" level="INFO" doc:name="Logger"/>
@@ -103,10 +97,12 @@ return sdf.parse(sdf.format(c.getTime()));
     <choice doc:name="Choice">
       <when expression="#[flowVars.labelNames.contains(flowVars.CompliedStatus) &amp;&amp; !flowVars.labelNames.contains(flowVars.ViolationStatus)]">
         <flow-ref name="QuerySFforContactAndAccount" doc:name="QuerySFforContactAndAccount"/>
+        <flow-ref name="QuerySFforAdminContactAndAccount" doc:name="QuerySFforAdminContactAndAccount"/>
         <flow-ref name="PushPropertytoSalesforce" doc:name="PushPropertytoSalesforce"/>
       </when>
       <when expression="#[flowVars.labelNames.contains(flowVars.ViolationStatus) &amp;&amp; !flowVars.labelNames.contains(flowVars.CompliedStatus)]">
         <flow-ref name="QuerySFforContactAndAccount" doc:name="QuerySFforContactAndAccount"/>
+        <flow-ref name="QuerySFforAdminContactAndAccount" doc:name="QuerySFforAdminContactAndAccount"/>
         <flow-ref name="PushPropertytoSalesforce" doc:name="PushPropertytoSalesforce"/>
       </when>
       <when expression="#[flowVars.labelNames.contains(flowVars.ViolationStatus) &amp;&amp; flowVars.labelNames.contains(flowVars.CompliedStatus)]">
@@ -124,8 +120,6 @@ return sdf.parse(sdf.format(c.getTime()));
   <sub-flow name="QuerySFforContactAndAccount">
     <set-variable variableName="contactEmail" value="#[flowVars.PropertyDetails.state.extra_data[&quot;Email&quot;].trim()]" doc:name="Variable: Contact Email useful for getting SF Account"/>
     <set-variable variableName="ContactName" value="#[flowVars.PropertyDetails.state.extra_data[&quot;On Behalf Of&quot;]]" doc:name="Variable: Contact Name"/>
-    <set-payload value=" #[flowVars.PropertyDetails.state.extra_data.Email.trim()]" doc:name="Set Payload"/>
-
     <sfdc:query-single config-ref="Testbed-Salesforce" query="Select Id, Email, Account.Name from Contact where Email = '#[flowVars.contactEmail]'" doc:name="Salesforce: Call for Contact and Account details"/>
     <choice doc:name="Choice">
       <when expression="#[payload != null]">
@@ -160,7 +154,6 @@ return sdf.parse(sdf.format(c.getTime()));
             <set-variable variableName="SFAccountId" value="#[payload[0].id]" doc:name="Variable: Set the SF Account ID"/>
           </otherwise>
         </choice>
-
       </otherwise>
     </choice>
     <scripting:transformer doc:name="Groovy: map fields to new Contact">
@@ -175,7 +168,59 @@ return sdf.parse(sdf.format(c.getTime()));
       <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;.  \n As a result the SEED property named: [(&quot;  + flowVars.PropertyName + &quot;),  Seed ID: (&quot; + flowVars.PropertyId + &quot;)] will not be updated in Salesforce until the issue is resolved.  Confirm that the SEED 'Organization' field&#160;has an exact match with the Salesforce 'Account Name'. If they do not match then update one so that they do.&quot;]" doc:name="Variable"/>
     </catch-exception-strategy>
   </flow>
-
+  <sub-flow name="QuerySFforAdminContactAndAccount">
+    <set-payload value="#[flowVars.PropertyDetails.state.extra_data[&quot;Property Data Administrator - Email&quot;]]" doc:name="Set Payload: Property Data Administrator &#8211; Email"/>
+    <expression-filter expression="#[payload != null]" doc:name="Expression"/>
+    <set-variable variableName="contactEmail" value="#[payload.trim()]" doc:name="Variable: Contact Email useful for getting SF Account"/>
+    <set-variable variableName="ContactName" value="#[flowVars.PropertyDetails.state.extra_data[&quot;Property Data Administrator&quot;]]" doc:name="Variable: Contact Name"/>
+    <sfdc:query-single config-ref="Testbed-Salesforce" query="Select Id, Email, Account.Name from Contact where Email = '#[flowVars.contactEmail]'" doc:name="Salesforce: Call for Contact and Account details"/>
+    <choice doc:name="Choice">
+      <when expression="#[payload != null]">
+        <set-variable variableName="AdminContactResults" value="#[payload.Id]" doc:name="Variable: Contact details"/>
+      </when>
+      <otherwise>
+        <flow-ref name="CreateAdminContactAndAccount" doc:name="CreateContactAndAccount"/>
+      </otherwise>
+    </choice>
+  </sub-flow>
+  <flow name="CreateAdminContactAndAccount">
+    <set-variable variableName="AccountName" value="#[flowVars.PropertyDetails.state.extra_data[&quot;Organization&quot;].trim()]" doc:name="Variable: SF Account Name"/>
+    <sfdc:query-single config-ref="Testbed-Salesforce" query="Select Id from Account where Name = '#[flowVars.AccountName.replace(&quot;'&quot;, &quot;\\'&quot;)]'" doc:name="Salesforce: Get Account if available"/>
+    <choice doc:name="Choice">
+      <when expression="#[payload != null]">
+        <logger message="Found Account with Name: #[flowVars.AccountName]" level="INFO" doc:name="Logger"/>
+        <set-variable variableName="SFPropertyAdminAccountId" value="#[payload.Id]" doc:name="Variable: SF Account Id"/>
+      </when>
+      <otherwise>
+        <set-variable variableName="DefaultAccountRecordType" value="${salesforce.DefaultAccountType}" doc:name="Variable: Default record type"/>
+        <scripting:transformer doc:name="Groovy: map name and record type to new Account">
+          <scripting:script engine="Groovy" file="AccountToSalesforce.groovy"/>
+        </scripting:transformer>
+        <sfdc:create config-ref="Testbed-Salesforce" type="Account" doc:name="Salesforce: Create a new Account">
+          <sfdc:objects ref="#[payload]"/>
+        </sfdc:create>
+        <choice doc:name="Choice">
+          <when expression="#[payload[0].success == 'false']">
+            <logger message="#['Error: ' +  payload]" level="INFO" doc:name="Logger"/>
+          </when>
+          <otherwise>
+            <set-variable variableName="SFPropertyAdminAccountId" value="#[payload[0].id]" doc:name="Variable: Set the SF Property Admin Account ID"/>
+          </otherwise>
+        </choice>
+      </otherwise>
+    </choice>
+    <scripting:transformer doc:name="Groovy: map fields to new Contact">
+      <scripting:script engine="Groovy" file="ContactToSalesforce.groovy"/>
+    </scripting:transformer>
+    <sfdc:create config-ref="Testbed-Salesforce" type="Contact" doc:name="Salesforce: Create a new SF contact">
+      <sfdc:objects ref="#[payload]"/>
+    </sfdc:create>
+    <set-variable variableName="AdminContactResults" value="#[payload[0].id]" doc:name="Variable: Save the SF Contact Id"/>
+    <catch-exception-strategy doc:name="pollseedforpropertiesCatch_Exception_Strategy">
+      <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;\n \n [Error4] Salesforce Account: '&quot; + flowVars.AccountName + &quot;' with Salesforce Contact email: '&quot; + flowVars.contactEmail + &quot;' aren't already objects in Salesforce but could not be created due to:  ==&gt; &quot; +exception.cause.?message or exception.cause]" doc:name="Variable"/>
+      <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;.  \n As a result the SEED property named: [(&quot;  + flowVars.PropertyName + &quot;),  Seed ID: (&quot; + flowVars.PropertyId + &quot;)] will not be updated in Salesforce until the issue is resolved.  Confirm that the SEED 'Organization' field&#160;has an exact match with the Salesforce 'Account Name'. If they do not match then update one so that they do.&quot;]" doc:name="Variable"/>
+    </catch-exception-strategy>
+  </flow>
   <sub-flow name="PushPropertytoSalesforce">
     <choice doc:name="Choice">
       <when expression="#[flowVars.IsInViolation]">
@@ -189,6 +234,7 @@ Property =
 [
 	Id: propData["Benchmark Salesforce ID"],
 	oei__Contact_Name__c: flowVars["ContactResults"],
+	oei_Property_Data_Administrator__c: flowVars["AdminContactResults"],
 	oei__Status__c: flowVars["IsInViolation"] ? flowVars["ViolationStatus"] : flowVars["CompliedStatus"],
 	oei__SEED_Labels__c: flowVars["labelNameString"]
 ]

--- a/SEED Benchmark/OEI/pollseedforproperties.xml
+++ b/SEED Benchmark/OEI/pollseedforproperties.xml
@@ -1,24 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<mule xmlns:schedulers="http://www.mulesoft.org/schema/mule/schedulers"
-      xmlns:file="http://www.mulesoft.org/schema/mule/file" xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
-      xmlns:sfdc="http://www.mulesoft.org/schema/mule/sfdc" xmlns:json="http://www.mulesoft.org/schema/mule/json"
-      xmlns:http="http://www.mulesoft.org/schema/mule/http"
-      xmlns:scripting="http://www.mulesoft.org/schema/mule/scripting"
-      xmlns:tracking="http://www.mulesoft.org/schema/mule/ee/tracking" xmlns="http://www.mulesoft.org/schema/mule/core"
-      xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
-      xmlns:spring="http://www.springframework.org/schema/beans"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
-http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
-http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
-http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
-http://www.mulesoft.org/schema/mule/json http://www.mulesoft.org/schema/mule/json/current/mule-json.xsd
-http://www.mulesoft.org/schema/mule/ee/tracking http://www.mulesoft.org/schema/mule/ee/tracking/current/mule-tracking-ee.xsd
-http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mule/scripting/current/mule-scripting.xsd
-http://www.mulesoft.org/schema/mule/sfdc http://www.mulesoft.org/schema/mule/sfdc/current/mule-sfdc.xsd
-http://www.mulesoft.org/schema/mule/file http://www.mulesoft.org/schema/mule/file/current/mule-file.xsd
-http://www.mulesoft.org/schema/mule/schedulers http://www.mulesoft.org/schema/mule/schedulers/current/mule-schedulers.xsd">
+<mule xmlns:schedulers="http://www.mulesoft.org/schema/mule/schedulers" xmlns:file="http://www.mulesoft.org/schema/mule/file" xmlns:vm="http://www.mulesoft.org/schema/mule/vm" xmlns:sfdc="http://www.mulesoft.org/schema/mule/sfdc" xmlns:json="http://www.mulesoft.org/schema/mule/json" xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns:scripting="http://www.mulesoft.org/schema/mule/scripting" xmlns:tracking="http://www.mulesoft.org/schema/mule/ee/tracking" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:spring="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd http://www.mulesoft.org/schema/mule/json http://www.mulesoft.org/schema/mule/json/current/mule-json.xsd http://www.mulesoft.org/schema/mule/ee/tracking http://www.mulesoft.org/schema/mule/ee/tracking/current/mule-tracking-ee.xsd http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mule/scripting/current/mule-scripting.xsd http://www.mulesoft.org/schema/mule/sfdc http://www.mulesoft.org/schema/mule/sfdc/current/mule-sfdc.xsd http://www.mulesoft.org/schema/mule/file http://www.mulesoft.org/schema/mule/file/current/mule-file.xsd http://www.mulesoft.org/schema/mule/schedulers http://www.mulesoft.org/schema/mule/schedulers/current/mule-schedulers.xsd">
 
   <flow name="pollseedforpropertiesFlow">
     <poll doc:name="Poll">
@@ -30,8 +10,7 @@ http://www.mulesoft.org/schema/mule/schedulers http://www.mulesoft.org/schema/mu
 
     <json:json-to-object-transformer returnClass="java.lang.Object" doc:name="JSON to Object"/>
     <set-variable variableName="ErrorLog" value="" doc:name="Variable: Declare Error Log"/>
-    <set-variable variableName="IndicationLabel" value="${SEED.IndicationLabel}"
-                  doc:name="Variable: Store the SEED Indication Label from configuration"/>
+    <set-variable variableName="IndicationLabel" value="${SEED.IndicationLabel}" doc:name="Variable: Store the SEED Indication Label from configuration"/>
     <foreach collection="#[payload.organizations]" doc:name="For Each">
       <set-variable variableName="organization_id" value="#[payload.org_id]" doc:name="Variable"/>
       <logger message="Calling for properties for Org ID: #[flowVars.organization_id]" level="INFO" doc:name="Logger"/>
@@ -50,21 +29,14 @@ http://www.mulesoft.org/schema/mule/schedulers http://www.mulesoft.org/schema/mu
         <![CDATA[return new Date().format('yyyy-MM-dd HH:mm:ss.SSS');]]></scripting:script>
     </scripting:component>
     <file:outbound-endpoint path="/tmp/oep" outputPattern="lastReadDate.txt" responseTimeout="10000" doc:name="File"/>
-    <catch-exception-strategy doc:name="Catch Exception Strategy"
-                              doc:description="Exception handling for the C2M listener">
-      <set-variable variableName="ErrorLog"
-                    value="#[flowVars.ErrorLog + &quot;\n \n [Info1] &quot; + exception.getEvent() + &quot;with the following details: \n&quot; + exception.getCauseException()]"
-                    doc:name="Variable: Update Error Log"/>
+    <catch-exception-strategy doc:name="Catch Exception Strategy" doc:description="Exception handling for the C2M listener">
+      <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;\n \n [Info1] &quot; + exception.getEvent() + &quot;with the following details: \n&quot; + exception.getCauseException()]" doc:name="Variable: Update Error Log"/>
       <flow-ref name="ErrorHandler" doc:name="ErrorHandler"/>
     </catch-exception-strategy>
   </flow>
   <flow name="getpropertiesfororg" processingStrategy="synchronous">
-    <set-variable variableName="SeedPath"
-                  value="/labels/filter/?inventory_type=property_view&amp;organization_id=#[flowVars.organization_id]"
-                  doc:name="Variable"/>
-    <http:request config-ref="SEED_API"
-                  path="/labels/filter/?inventory_type=property_view&amp;organization_id=#[flowVars.organization_id]"
-                  method="POST" doc:name="HTTP: Get all labels for my organization"/>
+    <set-variable variableName="SeedPath" value="/labels/filter/?inventory_type=property_view&amp;organization_id=#[flowVars.organization_id]" doc:name="Variable"/>
+    <http:request config-ref="SEED_API" path="/labels/filter/?inventory_type=property_view&amp;organization_id=#[flowVars.organization_id]" method="POST" doc:name="HTTP: Get all labels for my organization"/>
     <json:json-to-object-transformer returnClass="java.lang.Object" doc:name="JSON to Object"/>
     <scripting:transformer doc:name="Groovy: only look at properties with the 'Add to Salesforce' Label">
       <scripting:script engine="Groovy">
@@ -75,22 +47,17 @@ http://www.mulesoft.org/schema/mule/schedulers http://www.mulesoft.org/schema/mu
       <flow-ref name="GetPropertyDetailsFromSEED" doc:name="GetPropertyDetailsFromSEED"/>
     </foreach>
     <catch-exception-strategy doc:name="Catch Exception Strategy">
-      <set-variable variableName="ErrorLog"
-                    value="#['Calling ' + ${SEED.url}  + flowVars.SeedPath + ' resulted in the response:  \n \n ' + message.payloadAs(java.lang.String)]"
-                    doc:name="Variable"/>
+      <set-variable variableName="ErrorLog" value="#['Calling ' + ${SEED.url}  + flowVars.SeedPath + ' resulted in the response:  \n \n ' + message.payloadAs(java.lang.String)]" doc:name="Variable"/>
       <flow-ref name="ErrorHandler" doc:name="Flow Reference"/>
     </catch-exception-strategy>
   </flow>
   <flow name="GetPropertyDetailsFromSEED">
     <set-variable variableName="PropertyId" value="#[payload]" doc:name="Variable: SEED Property Id"/>
-    <http:request config-ref="SEED_API" path="/properties/#[payload]/?organization_id=#[flowVars.organization_id]"
-                  method="GET" doc:name="HTTP: Call for Details"/>
+    <http:request config-ref="SEED_API" path="/properties/#[payload]/?organization_id=#[flowVars.organization_id]" method="GET" doc:name="HTTP: Call for Details"/>
     <json:json-to-object-transformer returnClass="java.lang.Object" doc:name="JSON to Object"/>
     <set-variable variableName="PropertyDetails" value="#[payload]" doc:name="Variable: Property Details"/>
-    <set-variable variableName="PropertyName" value="#[flowVars.PropertyDetails.state.property_name]"
-                  doc:name="Variable: SEED Property Name"/>
-    <set-variable variableName="updatedDate" value="#[flowVars.PropertyDetails.property.updated]"
-                  doc:name="Variable: Get Updated Date"/>
+    <set-variable variableName="PropertyName" value="#[flowVars.PropertyDetails.state.property_name]" doc:name="Variable: SEED Property Name"/>
+    <set-variable variableName="updatedDate" value="#[flowVars.PropertyDetails.property.updated]" doc:name="Variable: Get Updated Date"/>
     <scripting:component doc:name="Groovy: get the last processed dates for comparison ">
       <scripting:script engine="Groovy"><![CDATA[import java.util.GregorianCalendar;
 import java.util.Calendar;
@@ -115,10 +82,8 @@ return sdf.parse(sdf.format(c.getTime()));
 
 ]]></scripting:script>
     </scripting:component>
-    <expression-filter expression="#[flowVars.seedDate &gt; payload]"
-                       doc:name="Expression: Filter anything not recently updated"/>
-    <logger message="Getting details for labels from Property: #[flowVars.PropertyDetails.property.id]" level="INFO"
-            doc:name="Logger"/>
+    <expression-filter expression="#[flowVars.seedDate &gt; payload]" doc:name="Expression: Filter anything not recently updated"/>
+    <logger message="Getting details for labels from Property: #[flowVars.PropertyDetails.property.id]" level="INFO" doc:name="Logger"/>
     <set-variable variableName="labelNames" value="#[[]]" doc:name="Variable: Array of Label Names"/>
     <set-payload value=" #[flowVars.PropertyDetails.labels]" mimeType="application/json" doc:name="Set Payload"/>
     <json:json-to-object-transformer returnClass="java.lang.Object" doc:name="JSON to Object"/>
@@ -126,65 +91,42 @@ return sdf.parse(sdf.format(c.getTime()));
       <set-variable variableName="LabelID" value="#[payload]" doc:name="Variable"/>
       <http:request config-ref="SEED_API" path="/labels/#[payload]" method="GET" doc:name="HTTP: Get label name"/>
       <json:json-to-object-transformer returnClass="java.lang.Object" doc:name="JSON to Object"/>
-      <expression-transformer
-      expression="#[payload != null ? flowVars.labelNames.add(payload.name) : flowVars.labelNames ]"
-      doc:name="Expression: Add the label name to the collection"/>
+      <expression-transformer expression="#[payload != null ? flowVars.labelNames.add(payload.name) : flowVars.labelNames ]" doc:name="Expression: Add the label name to the collection"/>
     </foreach>
-    <set-variable variableName="ViolationStatus" value="${SEED.ViolationLabel}"
-                  doc:name="Variable: Set Violation Text"/>
+    <set-variable variableName="ViolationStatus" value="${SEED.ViolationLabel}" doc:name="Variable: Set Violation Text"/>
     <set-variable variableName="CompliedStatus" value="${SEED.CompliedLabel}" doc:name="Variable: Set Complied Text"/>
-    <set-variable variableName="IsInViolation"
-                  value="#[flowVars.labelNames.contains(flowVars.ViolationStatus) ? true : false]"
-                  doc:name="Variable: Does this property Comply?"/>
+    <set-variable variableName="IsInViolation" value="#[flowVars.labelNames.contains(flowVars.ViolationStatus) ? true : false]" doc:name="Variable: Does this property Comply?"/>
     <scripting:transformer doc:name="Flatten List of label names">
       <scripting:script engine="Groovy"><![CDATA[return flowVars.labelNames.join("; ")]]></scripting:script>
     </scripting:transformer>
-    <set-variable variableName="labelNameString" value="#[payload]"
-                  doc:name="Variable: Keep semicolon separated list of label names for later"/>
+    <set-variable variableName="labelNameString" value="#[payload]" doc:name="Variable: Keep semicolon separated list of label names for later"/>
     <choice doc:name="Choice">
-      <when
-      expression="#[flowVars.labelNames.contains(flowVars.CompliedStatus) &amp;&amp; !flowVars.labelNames.contains(flowVars.ViolationStatus)]">
+      <when expression="#[flowVars.labelNames.contains(flowVars.CompliedStatus) &amp;&amp; !flowVars.labelNames.contains(flowVars.ViolationStatus)]">
         <flow-ref name="QuerySFforContactAndAccount" doc:name="QuerySFforContactAndAccount"/>
         <flow-ref name="PushPropertytoSalesforce" doc:name="PushPropertytoSalesforce"/>
       </when>
-      <when
-      expression="#[flowVars.labelNames.contains(flowVars.ViolationStatus) &amp;&amp; !flowVars.labelNames.contains(flowVars.CompliedStatus)]">
+      <when expression="#[flowVars.labelNames.contains(flowVars.ViolationStatus) &amp;&amp; !flowVars.labelNames.contains(flowVars.CompliedStatus)]">
         <flow-ref name="QuerySFforContactAndAccount" doc:name="QuerySFforContactAndAccount"/>
         <flow-ref name="PushPropertytoSalesforce" doc:name="PushPropertytoSalesforce"/>
       </when>
-      <when
-      expression="#[flowVars.labelNames.contains(flowVars.ViolationStatus) &amp;&amp; flowVars.labelNames.contains(flowVars.CompliedStatus)]">
-        <set-variable variableName="ErrorLog"
-                      value="#[flowVars.ErrorLog + &quot;\n \n [Error1] SEED property: &quot; + flowVars.PropertyDetails.state.property_name + &quot;, SEED Id: &quot; + flowVars.PropertyId + &quot;. Both '&quot; + flowVars.CompliedStatus + &quot;' AND '&quot; + flowVars.ViolationStatus + &quot;' labels have been applied to this property so no action will be taken.&quot; ]"
-                      doc:name="Variable: Error Log (both Complied and Violation statuses exist)"/>
+      <when expression="#[flowVars.labelNames.contains(flowVars.ViolationStatus) &amp;&amp; flowVars.labelNames.contains(flowVars.CompliedStatus)]">
+        <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;\n \n [Error1] SEED property: &quot; + flowVars.PropertyDetails.state.property_name + &quot;, SEED Id: &quot; + flowVars.PropertyId + &quot;. Both '&quot; + flowVars.CompliedStatus + &quot;' AND '&quot; + flowVars.ViolationStatus + &quot;' labels have been applied to this property so no action will be taken.&quot; ]" doc:name="Variable: Error Log (both Complied and Violation statuses exist)"/>
       </when>
       <otherwise>
-        <set-variable variableName="ErrorLog"
-                      value="#[flowVars.ErrorLog + &quot;\n \n [Error1] SEED property: &quot; + flowVars.PropertyDetails.state.property_name + &quot;, SEED Id: &quot; + flowVars.PropertyId + &quot;. Neither '&quot; + flowVars.CompliedStatus + &quot;' or '&quot; + flowVars.ViolationStatus + &quot;' labels have been applied to this property so no action will be taken.&quot; ]"
-                      doc:name="Variable: Error Log"/>
+        <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;\n \n [Error1] SEED property: &quot; + flowVars.PropertyDetails.state.property_name + &quot;, SEED Id: &quot; + flowVars.PropertyId + &quot;. Neither '&quot; + flowVars.CompliedStatus + &quot;' or '&quot; + flowVars.ViolationStatus + &quot;' labels have been applied to this property so no action will be taken.&quot; ]" doc:name="Variable: Error Log"/>
       </otherwise>
     </choice>
     <catch-exception-strategy doc:name="pollseedforpropertiesCatch_Exception_Strategy">
-      <set-variable variableName="ErrorLog"
-                    value="#[flowVars.ErrorLog + &quot;\n \n [Error4] SEED Label: '&quot; + flowVars.LabelID + &quot;' assigned to Property: &quot; + flowVars.PropertyName + &quot; has no details in SEED. &quot;]"
-                    doc:name="Variable"/>
-      <set-variable variableName="ErrorLog"
-                    value="#[flowVars.ErrorLog + &quot;.  \n As a result the SEED property named: [(&quot;  + flowVars.PropertyName + &quot;),  Seed ID: (&quot; + flowVars.PropertyId + &quot;)] will not be updated in Salesforce until the issue is resolved.  Confirm that the unavailable SEED label is removed from this property.&quot;]"
-                    doc:name="Variable"/>
+      <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;\n \n [Error4] SEED Label: '&quot; + flowVars.LabelID + &quot;' assigned to Property: &quot; + flowVars.PropertyName + &quot; has no details in SEED. &quot;]" doc:name="Variable"/>
+      <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;.  \n As a result the SEED property named: [(&quot;  + flowVars.PropertyName + &quot;),  Seed ID: (&quot; + flowVars.PropertyId + &quot;)] will not be updated in Salesforce until the issue is resolved.  Confirm that the unavailable SEED label is removed from this property.&quot;]" doc:name="Variable"/>
     </catch-exception-strategy>
   </flow>
   <sub-flow name="QuerySFforContactAndAccount">
-    <set-variable variableName="contactEmail"
-                  value="#[flowVars.PropertyDetails.state.extra_data[&quot;Email&quot;].trim()]"
-                  doc:name="Variable: Contact Email useful for getting SF Account"/>
-    <set-variable variableName="ContactName"
-                  value="#[flowVars.PropertyDetails.state.extra_data[&quot;On Behalf Of&quot;]]"
-                  doc:name="Variable: Contact Name"/>
+    <set-variable variableName="contactEmail" value="#[flowVars.PropertyDetails.state.extra_data[&quot;Email&quot;].trim()]" doc:name="Variable: Contact Email useful for getting SF Account"/>
+    <set-variable variableName="ContactName" value="#[flowVars.PropertyDetails.state.extra_data[&quot;On Behalf Of&quot;]]" doc:name="Variable: Contact Name"/>
     <set-payload value=" #[flowVars.PropertyDetails.state.extra_data.Email.trim()]" doc:name="Set Payload"/>
 
-    <sfdc:query-single config-ref="Testbed-Salesforce"
-                       query="Select Id, Email, Account.Name from Contact where Email = '#[flowVars.contactEmail]'"
-                       doc:name="Salesforce: Call for Contact and Account details"/>
+    <sfdc:query-single config-ref="Testbed-Salesforce" query="Select Id, Email, Account.Name from Contact where Email = '#[flowVars.contactEmail]'" doc:name="Salesforce: Call for Contact and Account details"/>
     <choice doc:name="Choice">
       <when expression="#[payload != null]">
         <set-variable variableName="ContactResults" value="#[payload.Id]" doc:name="Variable: Contact details"/>
@@ -195,20 +137,15 @@ return sdf.parse(sdf.format(c.getTime()));
     </choice>
   </sub-flow>
   <flow name="CreateContactAndAccount">
-    <set-variable variableName="AccountName"
-                  value="#[flowVars.PropertyDetails.state.extra_data[&quot;Organization&quot;].trim()]"
-                  doc:name="Variable: SF Account Name"/>
-    <sfdc:query-single config-ref="Testbed-Salesforce"
-                       query="Select Id from Account where Name = '#[flowVars.AccountName.replace(&quot;'&quot;, &quot;\\'&quot;)]'"
-                       doc:name="Salesforce: Get Account if available"/>
+    <set-variable variableName="AccountName" value="#[flowVars.PropertyDetails.state.extra_data[&quot;Organization&quot;].trim()]" doc:name="Variable: SF Account Name"/>
+    <sfdc:query-single config-ref="Testbed-Salesforce" query="Select Id from Account where Name = '#[flowVars.AccountName.replace(&quot;'&quot;, &quot;\\'&quot;)]'" doc:name="Salesforce: Get Account if available"/>
     <choice doc:name="Choice">
       <when expression="#[payload != null]">
         <logger message="Found Account with Name: #[flowVars.AccountName]" level="INFO" doc:name="Logger"/>
         <set-variable variableName="SFAccountId" value="#[payload.Id]" doc:name="Variable: SF Account Id"/>
       </when>
       <otherwise>
-        <set-variable variableName="DefaultAccountRecordType" value="${salesforce.DefaultAccountType}"
-                      doc:name="Variable: Default record type"/>
+        <set-variable variableName="DefaultAccountRecordType" value="${salesforce.DefaultAccountType}" doc:name="Variable: Default record type"/>
         <scripting:transformer doc:name="Groovy: map name and record type to new Account">
           <scripting:script engine="Groovy" file="AccountToSalesforce.groovy"/>
         </scripting:transformer>
@@ -220,8 +157,7 @@ return sdf.parse(sdf.format(c.getTime()));
             <logger message="#['Error: ' +  payload]" level="INFO" doc:name="Logger"/>
           </when>
           <otherwise>
-            <set-variable variableName="SFAccountId" value="#[payload[0].id]"
-                          doc:name="Variable: Set the SF Account ID"/>
+            <set-variable variableName="SFAccountId" value="#[payload[0].id]" doc:name="Variable: Set the SF Account ID"/>
           </otherwise>
         </choice>
 
@@ -235,12 +171,8 @@ return sdf.parse(sdf.format(c.getTime()));
     </sfdc:create>
     <set-variable variableName="ContactResults" value="#[payload[0].id]" doc:name="Variable: Save the SF Contact Id"/>
     <catch-exception-strategy doc:name="pollseedforpropertiesCatch_Exception_Strategy">
-      <set-variable variableName="ErrorLog"
-                    value="#[flowVars.ErrorLog + &quot;\n \n [Error4] Salesforce Account: '&quot; + flowVars.AccountName + &quot;' with Salesforce Contact email: '&quot; + flowVars.contactEmail + &quot;' aren't already objects in Salesforce but could not be created due to:  ==&gt; &quot; +exception.cause.?message or exception.cause]"
-                    doc:name="Variable"/>
-      <set-variable variableName="ErrorLog"
-                    value="#[flowVars.ErrorLog + &quot;.  \n As a result the SEED property named: [(&quot;  + flowVars.PropertyName + &quot;),  Seed ID: (&quot; + flowVars.PropertyId + &quot;)] will not be updated in Salesforce until the issue is resolved.  Confirm that the SEED 'Organization' field&#160;has an exact match with the Salesforce 'Account Name'. If they do not match then update one so that they do.&quot;]"
-                    doc:name="Variable"/>
+      <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;\n \n [Error4] Salesforce Account: '&quot; + flowVars.AccountName + &quot;' with Salesforce Contact email: '&quot; + flowVars.contactEmail + &quot;' aren't already objects in Salesforce but could not be created due to:  ==&gt; &quot; +exception.cause.?message or exception.cause]" doc:name="Variable"/>
+      <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;.  \n As a result the SEED property named: [(&quot;  + flowVars.PropertyName + &quot;),  Seed ID: (&quot; + flowVars.PropertyId + &quot;)] will not be updated in Salesforce until the issue is resolved.  Confirm that the SEED 'Organization' field&#160;has an exact match with the Salesforce 'Account Name'. If they do not match then update one so that they do.&quot;]" doc:name="Variable"/>
     </catch-exception-strategy>
   </flow>
 
@@ -272,9 +204,7 @@ return [Property]]]></scripting:script>
     </choice>
     <choice doc:name="Choice">
       <when expression="#[flowVars.SFPremiseId == '' || flowVars.SFPremiseId == null]">
-        <set-variable variableName="ErrorLog"
-                      value="#[flowVars.ErrorLog + &quot;\n \n [Error2] SEED property: &quot; + flowVars.PropertyDetails.state.property_name + &quot;, SEED property ID: &quot; + flowVars.PropertyId + &quot; 'Benchmark Salesforce ID' field is missing, there is no Salesforce object destination so no action will be taken.&quot;]"
-                      doc:name="Variable: update ErrorLog"/>
+        <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;\n \n [Error2] SEED property: &quot; + flowVars.PropertyDetails.state.property_name + &quot;, SEED property ID: &quot; + flowVars.PropertyId + &quot; 'Benchmark Salesforce ID' field is missing, there is no Salesforce object destination so no action will be taken.&quot;]" doc:name="Variable: update ErrorLog"/>
       </when>
       <otherwise>
         <sfdc:update config-ref="Testbed-Salesforce" type="oei__Benchmark__c" doc:name="Salesforce: Update Benchmark">
@@ -282,9 +212,7 @@ return [Property]]]></scripting:script>
         </sfdc:update>
         <choice doc:name="Choice">
           <when expression="#[payload[0].success == 'false']">
-            <set-variable variableName="ErrorLog"
-                          value="#[flowVars.ErrorLog + &quot;\n \n [Error3] For SEED property: &quot; + flowVars.PropertyDetails.state.property_name + &quot;, SEED Id: &quot; + flowVars.PropertyId + &quot; There was an error when updating Salesforce, which returned the following message: \n &quot; + payload[0].wrapped.errors[0].message]"
-                          doc:name="Variable: Update Error Log"/>
+            <set-variable variableName="ErrorLog" value="#[flowVars.ErrorLog + &quot;\n \n [Error3] For SEED property: &quot; + flowVars.PropertyDetails.state.property_name + &quot;, SEED Id: &quot; + flowVars.PropertyId + &quot; There was an error when updating Salesforce, which returned the following message: \n &quot; + payload[0].wrapped.errors[0].message]" doc:name="Variable: Update Error Log"/>
           </when>
           <otherwise>
             <logger message="#[payload]" level="INFO" doc:name="Logger"/>

--- a/SEED Benchmark/conf/oei.properties
+++ b/SEED Benchmark/conf/oei.properties
@@ -6,6 +6,7 @@ SEED.apikey=${SEED_APIKEY}
 SEED.protocol=${SEED_PROTOCOL}
 SEED.url=${SEED_URL}
 SEED.port=${SEED_PORT}
+SEED.apiversion=${SEED_APIVERSION}
 
 # Quartz expression to define the polling frequency to call SEED API for updated Benchmarks
 # http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html

--- a/SEED Benchmark/docker/start_mule.sh
+++ b/SEED Benchmark/docker/start_mule.sh
@@ -30,6 +30,11 @@ if [ -z ${SEED_PORT+x} ]; then
     exit 1
 fi
 
+if [ -z ${SEED_APIVERSION+x} ]; then
+    echo "SEED_APIVERSION is not set and is required"
+    exit 1
+fi
+
 if [ -z ${OEP_CRON_TIMER+x} ]; then
     echo "OEP_CRON_TIMER is not set and is required"
     exit 1
@@ -125,4 +130,4 @@ else
     export SMTP_SECURE=UNUSED
 fi
 
-/opt/mule/bin/mule
+/opt/mule/bin/mule -M-Dmule.verbose.exceptions=true

--- a/format_xml.py
+++ b/format_xml.py
@@ -2,7 +2,11 @@ import sys
 
 import lxml.etree as etree
 
+parser = etree.XMLParser(strip_cdata=False)
 filename = sys.argv[1]
-tree = etree.parse(filename)
+
+with open(filename) as f:
+    tree = etree.XML(f.read().encode(), parser=parser)
+
 with open(filename, 'wb') as f:
     f.write(etree.tostring(tree, pretty_print=True))

--- a/format_xml.py
+++ b/format_xml.py
@@ -1,0 +1,8 @@
+import sys
+
+import lxml.etree as etree
+
+filename = sys.argv[1]
+tree = etree.parse(filename)
+with open(filename, 'wb') as f:
+    f.write(etree.tostring(tree, pretty_print=True))

--- a/format_xml.py
+++ b/format_xml.py
@@ -2,11 +2,14 @@ import sys
 
 import lxml.etree as etree
 
-parser = etree.XMLParser(strip_cdata=False)
+parser = etree.XMLParser(strip_cdata=False, remove_blank_text=True)
 filename = sys.argv[1]
 
 with open(filename) as f:
     tree = etree.XML(f.read().encode(), parser=parser)
 
+# # for some reason, the first round of tostring isn't perfect formatting, so do it twice
+# tree_str = etree.tostring(tree)
+# tree2 = etree.XML(tree_str.decode(), parser=parser)
 with open(filename, 'wb') as f:
     f.write(etree.tostring(tree, pretty_print=True))


### PR DESCRIPTION
## Changes
- add xml formatter to pre-commit
- added Jeff's changes from e7189b6, which adds a new salesforce field Property Data Administrator)
- add a new required Env var, `SEED_APIVERSION`, which should be `v2` for now.

## Testing
I tested this with a locally running SEED instance and was able to update Property Data Administrator on my demo org. The property was labeled with the "add to salesforce" label and "complied" (also tested with the violation tag and it worked).

I had to create a new field for the Benchmark Object, `oei_PropertyData_Administrator__c` in salesforce. Note a _single_ underscore after oei b/c you cannot add double underscores to custom fields (unless it's a managed field, which the other oei ones can include b/c they are managed by the OEI app).

Resolves https://github.com/SEED-platform/seed/issues/2601