### PR TITLE
refactor: use SEED v3 api

### DIFF
--- a/SEED Benchmark/CHANGELOG.md
+++ b/SEED Benchmark/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## 1.7
 
 * Updated documentation to be markdown.
-* Add new Property Data Administrator field mapping from SEED to Salesfore
+* Add new Property Data Administrator field mapping from SEED to Salesforce
 * Add XML formatting
 * New SEED_APIVERSION field (defaults to v2 for now)
 

--- a/SEED Benchmark/CHANGELOG.md
+++ b/SEED Benchmark/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OEP / SEED Benchmark
 
+## 1.8 (Unreleased)
+
+* Update SEED's API to version 3
+* Remove the SEED_APIVERSION field as multiple versions are not supported
+
 ## 1.7
 
 * Updated documentation to be markdown.

--- a/SEED Benchmark/OEI/classes/pollseedforproperties.xml
+++ b/SEED Benchmark/OEI/classes/pollseedforproperties.xml
@@ -30,8 +30,12 @@
     </catch-exception-strategy>
   </flow>
   <flow name="getpropertiesfororg" processingStrategy="synchronous">
-    <set-variable variableName="SeedPath" value="/labels/filter/?inventory_type=property_view&amp;organization_id=#[flowVars.organization_id]" doc:name="Variable"/>
-    <http:request config-ref="SEED_API" path="/labels/filter/?inventory_type=property_view&amp;organization_id=#[flowVars.organization_id]" method="POST" doc:name="HTTP: Get all labels for my organization"/>
+    <set-variable variableName="SeedPath" value="/properties/labels/?organization_id=#[flowVars.organization_id]" doc:name="Variable"/>
+    <http:request config-ref="SEED_API" path="/properties/labels/?organization_id=#[flowVars.organization_id]" method="POST" doc:name="HTTP: Get all labels for my organization" sendBodyMode="NEVER">
+      <http:request-builder>
+        <http:header headerName="Content-Type" value="application/json" />
+      </http:request-builder>
+    </http:request>
     <json:json-to-object-transformer returnClass="java.lang.Object" doc:name="JSON to Object"/>
     <scripting:transformer doc:name="Groovy: only look at properties with the 'Add to Salesforce' Label">
       <scripting:script engine="Groovy"><![CDATA[return payload.find { it.name == flowVars.IndicationLabel }]]></scripting:script>

--- a/SEED Benchmark/OEI/global.xml
+++ b/SEED Benchmark/OEI/global.xml
@@ -9,7 +9,7 @@
   <sfdc:config doc:name="Salesforce" name="Testbed-Salesforce" password="${salesforce.password}" securityToken="${salesforce.token}" url="${salesforce.url}" username="${salesforce.user}">
     <sfdc:connection-pooling-profile exhaustedAction="WHEN_EXHAUSTED_GROW" initialisationPolicy="INITIALISE_ONE"/>
   </sfdc:config>
-  <http:request-config basePath="/api/${SEED.apiversion}" doc:name="HTTP Request Configuration" host="${SEED.url}" name="SEED_API" port="${SEED.port}" protocol="${SEED.protocol}">
+  <http:request-config basePath="/api/v3" doc:name="HTTP Request Configuration" host="${SEED.url}" name="SEED_API" port="${SEED.port}" protocol="${SEED.protocol}">
     <http:basic-authentication password="${SEED.apikey}" preemptive="true" username="${SEED.user}"/>
   </http:request-config>
   <flow name="DeadLetterFlow">

--- a/SEED Benchmark/OEI/pollseedforproperties.xml
+++ b/SEED Benchmark/OEI/pollseedforproperties.xml
@@ -30,8 +30,12 @@
     </catch-exception-strategy>
   </flow>
   <flow name="getpropertiesfororg" processingStrategy="synchronous">
-    <set-variable variableName="SeedPath" value="/labels/filter/?inventory_type=property_view&amp;organization_id=#[flowVars.organization_id]" doc:name="Variable"/>
-    <http:request config-ref="SEED_API" path="/labels/filter/?inventory_type=property_view&amp;organization_id=#[flowVars.organization_id]" method="POST" doc:name="HTTP: Get all labels for my organization"/>
+    <set-variable variableName="SeedPath" value="/properties/labels/?organization_id=#[flowVars.organization_id]" doc:name="Variable"/>
+    <http:request config-ref="SEED_API" path="/properties/labels/?organization_id=#[flowVars.organization_id]" method="POST" doc:name="HTTP: Get all labels for my organization" sendBodyMode="NEVER">
+      <http:request-builder>
+        <http:header headerName="Content-Type" value="application/json" />
+      </http:request-builder>
+    </http:request>
     <json:json-to-object-transformer returnClass="java.lang.Object" doc:name="JSON to Object"/>
     <scripting:transformer doc:name="Groovy: only look at properties with the 'Add to Salesforce' Label">
       <scripting:script engine="Groovy"><![CDATA[return payload.find { it.name == flowVars.IndicationLabel }]]></scripting:script>

--- a/SEED Benchmark/OEI/pom.xml
+++ b/SEED Benchmark/OEI/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.psd</groupId>
   <artifactId>oei</artifactId>
   <packaging>mule</packaging>
-  <version>1.7</version>
+  <version>1.8</version>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/SEED Benchmark/conf/oei.properties
+++ b/SEED Benchmark/conf/oei.properties
@@ -6,7 +6,6 @@ SEED.apikey=${SEED_APIKEY}
 SEED.protocol=${SEED_PROTOCOL}
 SEED.url=${SEED_URL}
 SEED.port=${SEED_PORT}
-SEED.apiversion=${SEED_APIVERSION}
 
 # Quartz expression to define the polling frequency to call SEED API for updated Benchmarks
 # http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html

--- a/SEED Benchmark/docker/start_mule.sh
+++ b/SEED Benchmark/docker/start_mule.sh
@@ -30,11 +30,6 @@ if [ -z ${SEED_PORT+x} ]; then
     exit 1
 fi
 
-if [ -z ${SEED_APIVERSION+x} ]; then
-    echo "SEED_APIVERSION is not set and is required"
-    exit 1
-fi
-
 if [ -z ${OEP_CRON_TIMER+x} ]; then
     echo "OEP_CRON_TIMER is not set and is required"
     exit 1


### PR DESCRIPTION
## Changes
- use seed v3 api for requests
- remove option to configure SEED API (doesn't make sense to allow this if APIs are different)

Resolves https://github.com/SEED-platform/seed/issues/2602